### PR TITLE
Import class instance instead of module

### DIFF
--- a/simcal/calibrators/base.py
+++ b/simcal/calibrators/base.py
@@ -2,7 +2,7 @@ import time
 from typing import Self
 
 import simcal.coordinators.base as Coordinator
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.parameters import Categorical, Value
 from simcal.parameters import Ordered
 from simcal.parameters import ParameterList

--- a/simcal/calibrators/bo.py
+++ b/simcal/calibrators/bo.py
@@ -9,7 +9,7 @@ from deephyper.problem import HpProblem
 import ConfigSpace as cs
 
 import simcal.calibrators as sc
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.parameters import Ordered, Categorical, Linear, Exponential
 
 from deephyper.evaluator.callback import Callback

--- a/simcal/calibrators/debug.py
+++ b/simcal/calibrators/debug.py
@@ -3,7 +3,7 @@ from time import time
 from typing import TextIO
 
 import simcal.coordinators.base as Coordinator
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.calibrators.base import Base as BaseCalibrator
 from simcal.parameters import Value
 

--- a/simcal/calibrators/genetic.py
+++ b/simcal/calibrators/genetic.py
@@ -6,7 +6,7 @@ from typing import Callable
 from simcal.calibrators.base import Base as BaseCalibrator
 import simcal.coordinators.base as Coordinator
 import simcal.exceptions as exception
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.parameters import *
 
 

--- a/simcal/calibrators/gradient.py
+++ b/simcal/calibrators/gradient.py
@@ -6,7 +6,7 @@ from sklearn.preprocessing import normalize
 import simcal.calibrators as sc
 import simcal.coordinators.base as Coordinator
 import simcal.exceptions as exception
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.calibrators.base import Base as BaseCalibrator
 from simcal.parameters import Base as parameter
 from simcal.parameters import Value

--- a/simcal/calibrators/grid.py
+++ b/simcal/calibrators/grid.py
@@ -7,7 +7,7 @@ from numpy import linspace
 
 import simcal.coordinators.base as Coordinator
 import simcal.exceptions as exception
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.calibrators.base import Base as BaseCalibrator
 from simcal.parameters import Value
 

--- a/simcal/calibrators/random.py
+++ b/simcal/calibrators/random.py
@@ -2,7 +2,7 @@ import random
 from itertools import count
 from time import time
 import simcal.exceptions as exception
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 
 from simcal.calibrators.base import Base as BaseCalibrator
 import simcal.coordinators.base as Coordinator

--- a/simcal/calibrators/skopt.py
+++ b/simcal/calibrators/skopt.py
@@ -6,7 +6,7 @@ import skopt.space as sks
 
 import simcal.coordinators.base as Coordinator
 import simcal.exceptions as exception
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal.calibrators.base import Base as BaseCalibrator
 from simcal.parameters import *
 

--- a/simcal/evaluation/loss_cloud.py
+++ b/simcal/evaluation/loss_cloud.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import numpy
 
-import simcal.simulator as Simulator
+from simcal.simulator import Simulator
 from simcal import parameter, exception
 from simcal.calibrators import Base as BaseCalibrator
 from simcal.calibrators.grid import _RectangularIterator


### PR DESCRIPTION
Instead of importing a module with an alias Simulator that is later magically resolved to the correct class instance Simulator implemented in this module, when it is called in the code below, a direct import of the class should be done.